### PR TITLE
update settings to reflect upstream options

### DIFF
--- a/game.libretro.beetle-psx/resources/language/English/strings.po
+++ b/game.libretro.beetle-psx/resources/language/English/strings.po
@@ -21,17 +21,53 @@ msgid "Settings"
 msgstr ""
 
 msgctxt "#30001"
-msgid "Dithering"
+msgid "CD Image Cache"
 msgstr ""
 
 msgctxt "#30002"
-msgid "Dualshock analog button"
+msgid "Skip BIOS"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Port 1: Multitap enable"
+msgid "Widescreen mode hack"
 msgstr ""
 
 msgctxt "#30004"
+msgid "Widescreen hack auto aspect ratio"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Memcard 0 method"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Shared memcards"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Initial scanline"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Initial scanline PAL"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Last scanline"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Last scanline PAL"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Dualshock analog toggle"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Port 1: Multitap enable"
+msgstr ""
+
+msgctxt "#30013"
 msgid "Port 2: Multitap enable"
 msgstr ""

--- a/game.libretro.beetle-psx/resources/settings.xml
+++ b/game.libretro.beetle-psx/resources/settings.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 	<category label="30000">
-		<setting label="30001" type="labelenum" id="psx_dithering" values="enabled|disabled" default="enabled"/>
-		<setting label="30002" type="labelenum" id="psx_enable_analog_toggle" values="disabled|enabled" default="disabled"/>
-		<setting label="30003" type="labelenum" id="psx_enable_multitap_port1" values="disabled|enabled" default="disabled"/>
-		<setting label="30004" type="labelenum" id="psx_enable_multitap_port2" values="disabled|enabled" default="disabled"/>
+		<setting label="30001" type="labelenum" id="beetle_psx_cdimagecache" values="enabled|disabled" default="disabled"/>
+		<setting label="30002" type="labelenum" id="beetle_psx_skipbios" values="enabled|disabled" default="disabled"/>
+		<setting label="30003" type="labelenum" id="beetle_psx_widescreen_hack" values="enabled|disabled" default="disabled"/>
+		<setting label="30004" type="labelenum" id="beetle_psx_widescreen_auto_ar" values="enabled|disabled" default="disabled"/>
+		<setting label="30005" type="labelenum" id="beetle_psx_use_mednafen_memcard0_method" values="libretro|mednafen" default="libretro"/>
+		<setting label="30006" type="labelenum" id="beetle_psx_shared_memory_cards" values="enabled|disabled" default="disabled"/>
+		<setting label="30007" type="labelenum" id="beetle_psx_initial_scanline" values="0|1|2|3|4|5|6|7|8|9|10|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40" default="0"/>
+		<setting label="30008" type="labelenum" id="beetle_psx_initial_scanline_pal" values="0|1|2|3|4|5|6|7|8|9|10|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40" default="0"/>
+		<setting label="30009" type="labelenum" id="beetle_psx_last_scanline" values="239|238|237|236|235|234|232|231|230|229|228|227|226|225|224|223|222|221|220|219|218|217|216|215|214|213|212|211|210" default="239"/>
+		<setting label="30010" type="labelenum" id="beetle_psx_last_scanline_pal" values="287|286|285|284|283|283|282|281|280|279|278|277|276|275|274|273|272|271|270|269|268|267|266|265|264|263|262|261|260" default="287"/>
+		<setting label="30011" type="labelenum" id="beetle_psx_analog_toggle" values="enabled|disabled" default="disabled"/>
+		<setting label="30012" type="labelenum" id="beetle_psx_enable_multitap_port1" values="enabled|disabled" default="disabled"/>
+		<setting label="30013" type="labelenum" id="beetle_psx_enable_multitap_port2" values="enabled|disabled" default="disabled"/>
 	</category>
 </settings>
-


### PR DESCRIPTION
I'm not sure if all are applicable to us, but it's better to be inline with what they use.

see, https://github.com/libretro/beetle-psx-libretro/blob/master/libretro.cpp#L3409...#L3421
