### PR TITLE
Update controller configs

### DIFF
--- a/game.libretro.beetle-psx/resources/buttonmap.xml
+++ b/game.libretro.beetle-psx/resources/buttonmap.xml
@@ -42,7 +42,7 @@
 		<feature name="strongmotor" mapto="RETRO_RUMBLE_STRONG"/>
 		<feature name="weakmotor" mapto="RETRO_RUMBLE_WEAK"/>
 	</controller>
-	<controller id="game.controller.ps.dualanalog" type="RETRO_DEVICE_ANALOG" subclass="2">
+	<controller id="game.controller.ps.dualanalog" type="RETRO_DEVICE_ANALOG" subclass="0">
 		<feature name="cross" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
 		<feature name="circle" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
 		<feature name="square" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
@@ -98,6 +98,7 @@
 		<feature name="pointer" mapto="RETRO_DEVICE_MOUSE"/>
 	</controller>
 	<!-- TODO
-	<controller id="game.controller.ps.negcon" type="RETRO_DEVICE_ANALOG" subclass="3"/>
+	<controller id="game.controller.ps.negcon" type="RETRO_DEVICE_ANALOG" subclass="2">
+	</controller>
 	-->
 </buttonmap>

--- a/game.libretro.beetle-psx/resources/topology.xml
+++ b/game.libretro.beetle-psx/resources/topology.xml
@@ -8,6 +8,7 @@
 		<accepts controller="game.controller.ps.guncon.japan"/>
 		<accepts controller="game.controller.konami.justifier.ps"/>
 		<accepts controller="game.controller.ps.mouse"/>
+		<!-- TODO: Multitap uses libretro options API for configuration
 		<accepts controller="game.controller.ps.multitap">
 			<port type="controller" id="1">
 				<accepts controller="game.controller.ps.dualshock"/>
@@ -46,6 +47,7 @@
 				<accepts controller="game.controller.ps.mouse"/>
 			</port>
 		</accepts>
+		-->
 	</port>
 	<port type="controller" id="2">
 		<accepts controller="game.controller.ps.dualshock"/>
@@ -55,6 +57,7 @@
 		<accepts controller="game.controller.ps.guncon.japan"/>
 		<accepts controller="game.controller.konami.justifier.ps"/>
 		<accepts controller="game.controller.ps.mouse"/>
+		<!-- TODO: Multitap uses libretro options API for configuration
 		<accepts controller="game.controller.ps.multitap">
 			<port type="controller" id="1">
 				<accepts controller="game.controller.ps.dualshock"/>
@@ -93,5 +96,6 @@
 				<accepts controller="game.controller.ps.mouse"/>
 			</port>
 		</accepts>
+		-->
 	</port>
 </logicaltopology>


### PR DESCRIPTION
## Description

This PR updates the button map and topology in accordance with the newest source:

https://github.com/libretro/beetle-psx-libretro/blob/e8609eb9b452e82eb8a5893c73d4ce50af55720c/libretro.cpp

It fixes the Dual Analog controller assignment. Also, multitap is now disabled because Beetle PSX uses the libretro options API for multitap configuration.

Currently, game.libretro only supports configuring multitaps through the input API. One option is to update Beetle PSX to use the input API instead of the options API for all input config.
